### PR TITLE
Add documentation to run specific plugins as root

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, Babak Farrokhi
+Copyright (c) 2017, Babak Farrokhi, Moritz Hoffmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ A set of FreeBSD specific plugins for Munin
 - You need to install `lang/gawk` in order to run `intr_` plugin.
 - You need to install `sysutils/ipmitool` in order to run `ipmi_` plugin.
 - These are wildcard plugins, and should be installed using `munin-node-configure` program
-- Some plugins such as `ipmi_` and `multiping_` need to have root access to run.
+- Some plugins such as `pf_`, `ipmi_` and `multiping_` need to have root access to run. To tell Munin to run a plugin as root, adapt the following snippet and add it to `/usr/local/etc/munin/plugin-conf.d/plugins.conf`:
+```
+[pf_*]
+user root
+```
 
 ## Setup
 1. Make sure `sysutils/munin-node` is installed


### PR DESCRIPTION
This patch documents the process of running a certain plugin as a different user than `munin`.

Signed-off-by: Moritz Hoffmann <moritz.hoffmann@inf.ethz.ch>